### PR TITLE
Update documentation and GH Pages links

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@ particular script, open its documentation from the list below.
 
 ## Installation
 
-The extension which manages your user scripts may be able to install them
-directly from GitHub, by looking at the "raw" version of the file (via the
-Raw button at the top of the file's page). Alternatively, it may be happier
-installing them from one of the following common sources of user scripts:
+You can install these user scripts from any of the three places listed below.
+Note, however, that installing directly from GitHub Pages likely won't allow the
+extension which manages your user scripts to update them automatically.
 
+- [GitHub Pages](https://benblank.github.io/user-scripts/)
 - [Greasy Fork](https://greasyfork.org/en/users/928949-benblank)
 - [OpenUserJS](https://openuserjs.org/users/five35/scripts)
 

--- a/scripts/feedly-unread-count-in-title.md
+++ b/scripts/feedly-unread-count-in-title.md
@@ -1,9 +1,11 @@
+## Feedly: Unread count in title
+
 Feedly doesn't provide a way for you to know how many unread items you have in
 your feed when you aren't actually looking at it (e.g. Feedly is minimized or in
 a different tab). This script places the number of unread items in the page
 title, so that you can see it even when Feedly isn't visible.
 
-## Settings
+### Settings
 
 - **Show count of all unread items, not just items in the selected category**
 
@@ -33,7 +35,7 @@ title, so that you can see it even when Feedly isn't visible.
   When checked, the unread count will be prepended to the beginning of the
   title. When unchecked (the default), it will be appended to the end.
 
-## Troubleshooting
+### Troubleshooting
 
 - _The number of unread items isn't appearing in the title!_
 

--- a/scripts/feedly-unread-count-in-title.user.js
+++ b/scripts/feedly-unread-count-in-title.user.js
@@ -4,7 +4,7 @@
 // @version     1.0
 // @author      Ben "535" Blank
 // @description Adds the number of unread items to the Feedly window title.
-// @homepageURL https://benblank.github.io/user-scripts/scripts/feedly-unread-count-in-title.md
+// @homepageURL https://benblank.github.io/user-scripts/scripts/feedly-unread-count-in-title.html
 // @supportURL  https://github.com/benblank/user-scripts/issues
 // @icon        https://benblank.github.io/user-scripts/scripts/feedly-unread-count-in-title.icon.png
 // @license     BSD-3-Clause


### PR DESCRIPTION
Now that I see how GH Pages displays the documentation, I wanted to tweak it a bit. Also, the `@homepageURL` links have been updated to point to the rendered HTML rather than the raw Markdown.