### PR TITLE
Fix typo in Range type for GM_config

### DIFF
--- a/libraries/gm-config-range-type.lib.js
+++ b/libraries/gm-config-range-type.lib.js
@@ -98,7 +98,7 @@
         id: `${this.configId}_field_${this.id}`,
         type: 'range',
         value: this.value,
-        ...pick(this.setings, ['min', 'max', 'step']),
+        ...pick(this.settings, ['min', 'max', 'step']),
       });
 
       const currentValue = this.create('span', {


### PR DESCRIPTION
A typo in the call to `pick` prevents the node from being created.