### PR TITLE
Add library versioning to URLs

### DIFF
--- a/libraries/gm-config-range-type.lib.js
+++ b/libraries/gm-config-range-type.lib.js
@@ -4,7 +4,7 @@
 
 // ==UserLibrary==
 // @name        Range type for GM_config
-// @version     1.0
+// @version     1.0.1
 // @author      Ben "535" Blank
 // @description Provides a range (slider) custom type for use with GM_config.
 // @homepageURL https://benblank.github.io/user-scripts/libraries/gm-config-range-type.html

--- a/libraries/gm-config-range-type.md
+++ b/libraries/gm-config-range-type.md
@@ -18,6 +18,12 @@ There are two steps to using this type: adding a `@require` line to your
 script's metadata block, and specifying it as a custom type when initializing
 GM_config.
 
+Note the version number in the library's URL on the `@require` line. Including
+it allows you to get a newer version of the library (by changing the version
+number to the latest) even if the user script extension doesn't support updating
+libraries. (The version number is ignore by GitHub Pages and exists solely for
+your script's benefit.)
+
 Example:
 
 ```javascript
@@ -25,7 +31,7 @@ Example:
 // @name      My Cool Script
 // @namespace https://example.com/
 // @match     https://*.example.com/*
-// @require   https://benblank.github.io/user-scripts/libraries/gm-config-range-type.lib.js
+// @require   https://benblank.github.io/user-scripts/libraries/gm-config-range-type.lib.js?v=1.0.1
 // @grant     GM_getValue
 // @grant     GM_registerMenuCommand
 // @grant     GM_setValue

--- a/scripts/feedly-unread-count-in-title.user.js
+++ b/scripts/feedly-unread-count-in-title.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name        Feedly: Unread count in title
 // @namespace   https://benblank.github.io/user-scripts/
-// @version     1.0.1
+// @version     1.0.2
 // @author      Ben "535" Blank
 // @description Adds the number of unread items to the Feedly window title.
 // @homepageURL https://benblank.github.io/user-scripts/scripts/feedly-unread-count-in-title.html
@@ -11,7 +11,7 @@
 // @copyright   2022 Ben Blank
 // @match       https://*.feedly.com/*
 // @require     https://openuserjs.org/src/libs/sizzle/GM_config.js
-// @require     https://benblank.github.io/user-scripts/libraries/gm-config-range-type.lib.js
+// @require     https://benblank.github.io/user-scripts/libraries/gm-config-range-type.lib.js?v=1.0.1
 // @grant       GM_getValue
 // @grant       GM_registerMenuCommand
 // @grant       GM_setValue


### PR DESCRIPTION
It appears that at least some user script managers (I'm looking at you, Violentmonkey) won't download new versions of `@require`d scripts under any conditions. It is therefore necessary to include a version number (or something similar) in the URL for cache-busting. Fortunately, GH Pages ignores query parameters.

Also includes the version number bump for gm-config-range-type missing from #4.