### PR TITLE
Site tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@ particular script, open its documentation from the list below.
 ## Installation
 
 You can install these user scripts from any of the three places listed below.
-Note, however, that installing directly from GitHub Pages likely won't allow the
-extension which manages your user scripts to update them automatically.
 
 - [GitHub Pages](https://benblank.github.io/user-scripts/)
 - [Greasy Fork](https://greasyfork.org/en/users/928949-benblank)

--- a/libraries/index.md
+++ b/libraries/index.md
@@ -1,0 +1,2 @@
+The complete list of available user script libraries can be found
+[on the main page](../README.md#libraries).

--- a/scripts/index.md
+++ b/scripts/index.md
@@ -1,0 +1,2 @@
+The complete list of available user scripts can be found
+[on the main page](../README.md#scripts).


### PR DESCRIPTION
Removes the GH Pages warning from the main README (as updating from the site seems to work just fine) and adds index pages to the `libraries` and `scripts` directories, linking back to the main README, so that those URLs don't generate 404s.

The indices could be made into library/script lists instead, but then they'd have to be maintained both there and in the main README (and I *do* want them to appear in the main README).