### PR TITLE
Update current value text when resetting

### DIFF
--- a/libraries/gm-config-range-type.lib.js
+++ b/libraries/gm-config-range-type.lib.js
@@ -4,7 +4,7 @@
 
 // ==UserLibrary==
 // @name        Range type for GM_config
-// @version     1.0.2
+// @version     1.0.3
 // @author      Ben "535" Blank
 // @description Provides a range (slider) custom type for use with GM_config.
 // @homepageURL https://benblank.github.io/user-scripts/libraries/gm-config-range-type.html
@@ -73,6 +73,10 @@
     reset() {
       if (this.wrapper) {
         this.wrapper.querySelector(`#${this.configId}_field_${this.id}`).value = this.settings.default;
+
+        this.wrapper.querySelector(`.${this.configId}_${this.id}_current_value`).textContent = (
+          this.settings.formatter ?? defaultFormatter
+        )(this.settings.default, this.settings);
       }
     },
 

--- a/scripts/feedly-unread-count-in-title.user.js
+++ b/scripts/feedly-unread-count-in-title.user.js
@@ -11,7 +11,7 @@
 // @copyright   2022 Ben Blank
 // @match       https://*.feedly.com/*
 // @require     https://openuserjs.org/src/libs/sizzle/GM_config.js
-// @require     https://benblank.github.io/user-scripts/libraries/gm-config-range-type.lib.js?v=1.0.1
+// @require     https://benblank.github.io/user-scripts/libraries/gm-config-range-type.lib.js?v=1.0.3
 // @grant       GM_getValue
 // @grant       GM_registerMenuCommand
 // @grant       GM_setValue

--- a/scripts/youtube-watched-badge.user.js
+++ b/scripts/youtube-watched-badge.user.js
@@ -11,7 +11,7 @@
 // @copyright   2022 Ben Blank
 // @match       https://*.youtube.com/*
 // @require     https://openuserjs.org/src/libs/sizzle/GM_config.js
-// @require     https://benblank.github.io/user-scripts/libraries/gm-config-range-type.lib.js?v=1.0.2
+// @require     https://benblank.github.io/user-scripts/libraries/gm-config-range-type.lib.js?v=1.0.3
 // @grant       GM_getValue
 // @grant       GM_registerMenuCommand
 // @grant       GM_setValue


### PR DESCRIPTION
The `input` event handler doesn't appear to be called when setting an input's `value=` attribute. (Nor does the `change` event handler.) Instead, the "current value" text needs updated directly by the reset handler.