### PR TITLE
Bump versions of scripts with updated libraries

### DIFF
--- a/scripts/feedly-unread-count-in-title.user.js
+++ b/scripts/feedly-unread-count-in-title.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name        Feedly: Unread count in title
 // @namespace   https://benblank.github.io/user-scripts/
-// @version     1.0.3
+// @version     1.0.4
 // @author      Ben "535" Blank
 // @description Adds the number of unread items to the Feedly window title.
 // @homepageURL https://benblank.github.io/user-scripts/scripts/feedly-unread-count-in-title.html

--- a/scripts/youtube-watched-badge.user.js
+++ b/scripts/youtube-watched-badge.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name        YouTube: Watched badge
 // @namespace   https://benblank.github.io/user-scripts/
-// @version     1.0
+// @version     1.0.1
 // @author      Ben "535" Blank
 // @description Adds or improves "watched" badges on watched videos' thumbnails.
 // @homepageURL https://benblank.github.io/user-scripts/scripts/youtube-watched-badge.html


### PR DESCRIPTION
I forgot to bump the versions of "Feedly: Unread count in title" and "YouTube: Watched badge" when I updated their dependencies on "Range type for GM_config".