### PR TITLE
Remove Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: 'npm'
-    directory: '/'
-    versioning-strategy: 'increase'
-    schedule:
-      interval: 'daily'


### PR DESCRIPTION
Dependabot's version upgrade PRs generate far too much noise for such a small repository, especially when there are no production dependencies. Dependabot will be re-enabled, but only for security upgrades.